### PR TITLE
Prevent duplicate links

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_nodes"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Cameron Haigh <cgwhaigh@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/link.rs
+++ b/src/link.rs
@@ -75,7 +75,7 @@ impl PartialEq for LinkData {
             std::mem::swap(&mut rhs_start, &mut rhs_end);
         }
 
-        lhs_start == rhs_start && lhs_end == rhs_start
+        lhs_start == rhs_start && lhs_end == rhs_end
     }
 }
 


### PR DESCRIPTION
There was a bug in `link.rs` which allowed the same link to be created multiple times, even in the same direction.